### PR TITLE
chore: Add templates for filing issues and submitting pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug report
+description: Report a reproducible bug to help us improve
+title: "Bug: TITLE"
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for submitting a bug report. Please add as much information as possible to help us reproduce, and remove any potential sensitive data.
+  - type: textarea
+    id: expected_behaviour
+    attributes:
+      label: Expected Behaviour
+      description: Please share details on the behaviour you expected
+    validations:
+      required: true
+  - type: textarea
+    id: current_behaviour
+    attributes:
+      label: Current Behaviour
+      description: Please share details on the current issue
+    validations:
+      required: true
+  - type: textarea
+    id: code_snippet
+    attributes:
+      label: Code snippet
+      description: Please share a code snippet to help us reproduce the issue
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Possible Solution
+      description: If known, please suggest a potential resolution
+    validations:
+      required: false
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Please share how we might be able to reproduce this issue
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Amazon EKS one click upgrade version
+      placeholder: "latest"
+      value: latest
+    validations:
+      required: true
+  - type: dropdown
+    id: runtime
+    attributes:
+      label: Python runtime version
+      options:
+        - 3.8
+        - 3.9
+        - 3.10
+        - 3.11
+    validations:
+      required: true
+  - type: dropdown
+    id: packaging
+    attributes:
+      label: Packaging format used
+      options:
+        - Git clone
+        - PyPi
+      multiple: true
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Debugging logs
+      description: If available, please share debugging logs
+      render: python
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        **Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Ask a question
+    url: https://github.com/aws-samples/amazon-eks-one-click-cluster-upgrade/discussions/new
+    about: Ask a general question about Amazon EKS one click cluster upgrade

--- a/.github/ISSUE_TEMPLATE/documentation_improvements.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvements.yml
@@ -1,0 +1,50 @@
+name: Documentation improvements
+description: Suggest a documentation update to improve everyone's experience
+title: "Docs: TITLE"
+labels: ["documentation", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping us improve everyone's experience. We review documentation updates on a case by case basis.
+  - type: textarea
+    id: search_area
+    attributes:
+      label: What were you searching in the docs?
+      description: Please help us understand how you looked for information that was either unclear or not available
+    validations:
+      required: true
+  - type: input
+    id: area
+    attributes:
+      label: Is this related to an existing documentation section?
+      description: Please share a link, if applicable
+    validations:
+      required: false
+  - type: textarea
+    id: idea
+    attributes:
+      label: How can we improve?
+      description: Please share your thoughts on how we can improve this experience
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Got a suggestion in mind?
+      description: Please suggest a proposed update
+    validations:
+      required: false
+  - type: checkboxes
+    id: acknowledgment
+    attributes:
+      label: Acknowledgment
+      options:
+        - label: I understand the final update might be different from my proposed suggestion, or refused.
+          required: true
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        **Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest an idea
+title: "Feature request: TITLE"
+labels: ["feature-request", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to suggest an idea for the project.
+
+        *Future readers*: Please react with 👍 and your use case to help us understand customer demand.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Use case
+      description: Please help us understand your use case or problem you're facing
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Solution/User Experience
+      description: Please share what a good solution would look like to this use case
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternative solutions
+      description: Please describe what alternative solutions to this use case, if any
+      render: markdown
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        **Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,0 +1,49 @@
+name: Maintenance
+description: Suggest an activity to help address tech debt, governance, and anything internal
+title: "Maintenance: TITLE"
+labels: ["internal", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to help us improve operational excellence.
+
+        *Future readers*: Please react with 👍 and your use case to help us understand customer demand.
+  - type: textarea
+    id: activity
+    attributes:
+      label: Summary
+      description: Please provide an overview in one or two paragraphs
+    validations:
+      required: true
+  - type: textarea
+    id: importance
+    attributes:
+      label: Why is this needed?
+      description: Please help us understand the value so we can prioritize it accordingly
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Which area does this relate to?
+      multiple: true
+      options:
+        - Automation
+        - Dependencies
+        - Governance
+        - Tests
+        - Other
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Solution
+      description: If available, please share what a good solution would look like
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: |
+        ---
+
+        **Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!-- markdownlint-disable MD041 MD043 -->
+
+**Issue number:**
+
+## Summary
+
+### Changes
+
+> Please provide a summary of what's being changed
+
+### User experience
+
+> Please share what the user experience looks like before and after this change
+
+## Checklist
+
+If your change doesn't seem to apply, please leave them unchecked.
+
+- [ ] I have performed a self-review of this change
+- [ ] Changes have been tested
+- [ ] Changes are documented
+
+## Acknowledgment
+
+By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
+
+**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.

--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -1,0 +1,26 @@
+name: 'PR title'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          requireScope: false
+          subjectPattern: ^[A-Z].+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            starts with an uppercase character.
+          wip: true
+          validateSingleCommit: false


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

## Summary

### Changes

- Add templates for filing issues and submitting pull requests. These are taken from https://github.com/awslabs/aws-lambda-powertools-python as a starting point, we can change to suit over time

### User experience

- When users file issues, open feature requests, or submit PRs, they will now have a structured template that contains the information to help maintainers triage the request appropriately

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [ ] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.