### PR TITLE
refactor: Adjust the entrypoint to accept arguments and add version flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,85 @@
 .vscode/
-
-
+.DS_Store
+# Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class
-.DS_Store
 
-**/.DS_Store
+# C extensions
+*.so
 
-*.DS_Store
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/eksupgrade/cli.py
+++ b/eksupgrade/cli.py
@@ -3,15 +3,21 @@ from __future__ import annotations
 
 import argparse
 import logging
-from typing import List
+import sys
+from typing import List, Optional
 
+from eksupgrade import __version__
 from eksupgrade.starter import main
 
 logger = logging.getLogger(__name__)
 
 
-def entry() -> None:
+def entry(args: Optional[List[str]] = None) -> None:
     """Handle the CLI entrypoint argument parsing."""
+    # If no arguments are provided directly to the function, default to input.
+    if not args:
+        args = sys.argv[1:]
+
     example_text = """
 example:
 
@@ -33,6 +39,10 @@ Skip upgrade workflow:
 Set log level to console (default to INFO):
 
     -> eksupgrade cluster_name new_version aws_region --log-level debug
+
+Display the eksupgrade version:
+
+    -> eksupgrade --version
 
 """
 
@@ -67,7 +77,7 @@ Set log level to console (default to INFO):
     )
     parser.add_argument("name", help="Cluster Name")
     parser.add_argument("version", help="new version which you want to update")
-    parser.add_argument("region", help="Give the region name " + ", ".join(regions_list))
+    parser.add_argument("region", help=f"Give the region name {', '.join(regions_list)}")
     parser.add_argument(
         "--pass_vpc", action="store_true", default=False, help="this --pass-vpc will skip the vpc cni upgrade"
     )
@@ -83,10 +93,11 @@ Set log level to console (default to INFO):
     parser.add_argument(
         "--log-level", default="INFO", help="The log level to be displayed in the console. Default to: INFO"
     )
-    args = parser.parse_args()
-    logging.basicConfig(level=args.log_level.upper())
-    main(args)
+    parser.add_argument("--version", action="version", version=f"eksupgrade {__version__}")
+    parsed_arguments = parser.parse_args(args)
+    logging.basicConfig(level=parsed_arguments.log_level.upper())
+    main(parsed_arguments)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     entry()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,24 @@
+"""Test the functionality of the CLI module."""
+import pytest
+
+from eksupgrade.cli import entry
+
+
+def test_entry_version_arg(capsys) -> None:
+    """Test the entry method with version argument."""
+    with pytest.raises(SystemExit):
+        entry(["--version"])
+
+    captured = capsys.readouterr()
+    result = captured.out
+    assert result.startswith("eksupgrade")
+
+
+def test_entry_no_arg(capsys) -> None:
+    """Test the entry method with no arguments."""
+    with pytest.raises(SystemExit):
+        entry()
+
+    captured = capsys.readouterr()
+    result = captured.out
+    assert result.startswith("")


### PR DESCRIPTION
## Summary

### Changes

The goal of this PR is to modify the entry method to allow for easy passage of arguments to the parser method.  This ensures we can easily test the function.

### User experience

Only visible change to end users includes the capability to run: `eksupgrade --version`

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
