### PR TITLE
fix: Fix and update standard workflow to pull addon versions from EKS API

### DIFF
--- a/eksupgrade/src/S3Files/depricatedApi
+++ b/eksupgrade/src/S3Files/depricatedApi
@@ -65,5 +65,36 @@
           "scheduling.k8s.io/v1beta1": "scheduling.k8s.io/v1",
           "storage.k8s.io/v1beta1": "storage.k8s.io/v1"
         }
+      },
+      "1.23": {
+        "all-resources": {}
+      },
+      "1.24": {
+        "all-resources": {}
+      },
+      "1.25": {
+        "all-resources": {
+          "batch/v1beta1": "batch/v1",
+          "discovery.k8s.io/v1beta1": "discovery.k8s.io/v1",
+          "events.k8s.io/v1beta1": "events.k8s.io/v1",
+          "autoscaling/v2beta1": "autoscaling/v2",
+          "policy/v1beta1": "policy/v1",
+          "node.k8s.io/v1beta1": "node.k8s.io/v1"
+        }
+      },
+      "1.26": {
+        "flowcontrol.apiserver.k8s.io/v1beta1": "flowcontrol.apiserver.k8s.io/v1beta3",
+        "autoscaling/v2beta2": "autoscaling/v2"
+      },
+      "1.27": {
+        "storage.k8s.io/v1beta1": "storage.k8s.io/v1"
+      },
+      "1.28": {
+        "all-resources": {}
+      },
+      "1.29": {
+        "all-resources": {
+          "flowcontrol.apiserver.k8s.io/v1beta2": "flowcontrol.apiserver.k8s.io/v1beta3"
+        }
       }
   }

--- a/eksupgrade/src/S3Files/version_dict.json
+++ b/eksupgrade/src/S3Files/version_dict.json
@@ -1,33 +1,42 @@
 {
+    "1.26": {
+        "cluster-autoscaler": "1.26.1"
+    },
+    "1.25": {
+        "cluster-autoscaler": "1.25.0"
+    },
+    "1.24": {
+        "cluster-autoscaler": "1.24.0"
+    },
     "1.23": {
         "kube-proxy": "1.23.7-minimal-eksbuild.1",
         "coredns": "1.8.7-eksbuild.2",
         "vpc-cni": "1.11.3-eksbuild.1",
-        "cluster-autoscaler": "1.22.2"
-    },   
+        "cluster-autoscaler": "1.23.0"
+    },
     "1.22": {
         "kube-proxy": "1.22.11-eksbuild.2",
         "coredns": "1.8.7",
         "vpc-cni": "1.11.3-eksbuild.1",
         "cluster-autoscaler": "1.22.2"
-    },    
+    },
     "1.21": {
         "kube-proxy": "1.21.2",
         "coredns": "1.8.4",
         "vpc-cni": "1.9.3",
-        "cluster-autoscaler": "1.21.1"
+        "cluster-autoscaler": "1.21.2"
     },
     "1.20": {
         "kube-proxy": "1.20.4",
         "coredns": "1.8.3",
         "vpc-cni": "1.9.3",
-        "cluster-autoscaler": "1.20.1"
+        "cluster-autoscaler": "1.20.3"
     },
     "1.19": {
         "kube-proxy": "1.19.6",
         "coredns": "1.8.0",
         "vpc-cni": "1.7.10",
-        "cluster-autoscaler": "1.19.1"
+        "cluster-autoscaler": "1.19.3"
     },
     "1.18": {
         "kube-proxy": "1.18.8",

--- a/eksupgrade/src/k8s_client.py
+++ b/eksupgrade/src/k8s_client.py
@@ -327,7 +327,7 @@ def get_addon_update_kwargs(cluster_name: str, addon: str, region: str) -> Dict[
 
 
 def update_eks_addon(cluster_name: str, addon: str, region: str, version: str) -> Dict[str, Any]:
-    """Get target addon versions."""
+    """Update `addon` to `version`"""
     logger.info("Updating the EKS cluster's %s add-on version via the EKS API...", addon)
     eks_client = boto3.client("eks", region_name=region)
     update_kwargs: Dict[str, Any] = get_addon_update_kwargs(cluster_name, addon, region)

--- a/eksupgrade/src/k8s_client.py
+++ b/eksupgrade/src/k8s_client.py
@@ -303,7 +303,7 @@ def sort_pods(
 
 @cache
 def get_addon_details(cluster_name: str, addon: str, region: str) -> Dict[str, Any]:
-    """Get target addon versions."""
+    """Get addon details which includes its current version"""
     eks_client = boto3.client("eks", region_name=region)
     addon_details: Dict[str, Any] = eks_client.describe_addon(clusterName=cluster_name, addonName=addon).get(
         "addon", {}

--- a/eksupgrade/src/k8s_client.py
+++ b/eksupgrade/src/k8s_client.py
@@ -356,7 +356,7 @@ def get_versions_by_addon(addon: str, version: str, region: str) -> Dict[str, An
 
 @cache
 def get_default_version(addon: str, version: str, region: str) -> str:
-    """Get target addon versions."""
+    """Get the EKS default version of the `addon`."""
     addon_dict: Dict[str, Any] = get_versions_by_addon(addon, version, region)
     return next(
         item["addonVersion"]

--- a/eksupgrade/src/k8s_client.py
+++ b/eksupgrade/src/k8s_client.py
@@ -15,6 +15,11 @@ import threading
 import time
 from typing import Any, Dict, List, Optional, Union
 
+try:
+    from functools import cache
+except ImportError:
+    from functools import lru_cache as cache
+
 import boto3
 import yaml
 from botocore.signers import RequestSigner
@@ -248,7 +253,7 @@ def sort_pods(
     region: str,
     original_name: str,
     pod_name: str,
-    old_pods_name: List[str],
+    old_pods_names: List[str],
     namespace: str,
     count: int = 90,
 ) -> str:
@@ -286,14 +291,78 @@ def sort_pods(
         new_pod_name = sorted(pods_nodes, key=lambda x: x[1])[-1][0]
     else:
         count -= 1
-        sort_pods(cluster_name, region, original_name, pod_name, old_pods_name, namespace, count)
+        sort_pods(cluster_name, region, original_name, pod_name, old_pods_names, namespace, count)
         # TODO: Remove this.  Adding to resolve possible use before assignment below.
         new_pod_name = ""
 
-    if original_name != new_pod_name and new_pod_name in old_pods_name:
+    if original_name != new_pod_name and new_pod_name in old_pods_names:
         count -= 1
-        sort_pods(cluster_name, region, original_name, pod_name, old_pods_name, namespace, count)
+        sort_pods(cluster_name, region, original_name, pod_name, old_pods_names, namespace, count)
     return new_pod_name
+
+
+@cache
+def get_addon_details(cluster_name: str, addon: str, region: str) -> Dict[str, Any]:
+    """Get target addon versions."""
+    eks_client = boto3.client("eks", region_name=region)
+    addon_details: Dict[str, Any] = eks_client.describe_addon(clusterName=cluster_name, addonName=addon).get(
+        "addon", {}
+    )
+    return addon_details
+
+
+@cache
+def get_addon_update_kwargs(cluster_name: str, addon: str, region: str) -> Dict[str, Any]:
+    """Get kwargs for subsequent update to addon."""
+    addon_details: Dict[str, Any] = get_addon_details(cluster_name, addon, region)
+    kwargs: Dict[str, Any] = {}
+    iam_role_arn: Optional[str] = addon_details.get("serviceAccountRoleArn")
+    config_values: Optional[str] = addon_details.get("configurationValues")
+
+    if iam_role_arn:
+        kwargs["serviceAccountRoleArn"] = iam_role_arn
+    if config_values:
+        kwargs["configurationValues"] = config_values
+    return kwargs
+
+
+def update_eks_addon(cluster_name: str, addon: str, region: str, version: str) -> Dict[str, Any]:
+    """Get target addon versions."""
+    logger.info("Updating the EKS cluster's %s add-on version via the EKS API...", addon)
+    eks_client = boto3.client("eks", region_name=region)
+    update_kwargs: Dict[str, Any] = get_addon_update_kwargs(cluster_name, addon, region)
+    update_response: Dict[str, Any] = eks_client.update_addon(
+        clusterName=cluster_name, addonName=addon, addonVersion=version, resolveConflicts="OVERWRITE", **update_kwargs
+    )
+    return update_response
+
+
+@cache
+def get_addon_versions(version: str, region: str) -> List[Dict[str, Any]]:
+    """Get target addon versions."""
+    eks_client = boto3.client("eks", region_name=region)
+    addon_versions: List[Dict[str, Any]] = eks_client.describe_addon_versions(kubernetesVersion=version).get(
+        "addons", []
+    )
+    return addon_versions
+
+
+@cache
+def get_versions_by_addon(addon: str, version: str, region: str) -> Dict[str, Any]:
+    """Get target addon versions."""
+    addon_versions: List[Dict[str, Any]] = get_addon_versions(version, region)
+    return next(item for item in addon_versions if item["addonName"] == addon)
+
+
+@cache
+def get_default_version(addon: str, version: str, region: str) -> str:
+    """Get target addon versions."""
+    addon_dict: Dict[str, Any] = get_versions_by_addon(addon, version, region)
+    return next(
+        item["addonVersion"]
+        for item in addon_dict["addonVersions"]
+        if item["compatibilities"][0]["defaultVersion"] is True
+    )
 
 
 def update_addons(cluster_name: str, version: str, vpc_pass: bool, region_name: str) -> None:
@@ -304,6 +373,23 @@ def update_addons(cluster_name: str, version: str, vpc_pass: bool, region_name: 
         worker.setDaemon(True)
         worker.start()
 
+    def _container_spec(image_name: str, image_uri: str, image_tag: str) -> Dict[str, Any]:
+        """Return the container specification body payload to be used to patch the resource."""
+        return {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": image_name,
+                                "image": f"{image_uri}:{image_tag}",
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+
     core_v1_api = client.CoreV1Api()
     apps_v1_api = client.AppsV1Api()
     rep = core_v1_api.list_namespaced_pod("kube-system")
@@ -311,58 +397,45 @@ def update_addons(cluster_name: str, version: str, vpc_pass: bool, region_name: 
     with open("eksupgrade/src/S3Files/version_dict.json", "r", encoding="utf-8") as version_dict_file:
         add_on_dict: Dict[str, Any] = json.load(version_dict_file)
 
-    old_pods_name: List[str] = []
-
-    for pod in rep.items:
-        old_pods_name.append(pod.metadata.name)
-
-    logger.info("The Addons Found = %s", old_pods_name)
+    old_pods_names: List[str] = [_pod.metadata.name for _pod in rep.items]
+    logger.info("The Addons Found = %s", old_pods_names)
 
     flag_vpc, flag_core, flag_proxy, flag_scaler = True, True, True, True
+
+    coredns_new: str = get_default_version("coredns", version, region_name)
+    kubeproxy_new: str = get_default_version("kube-proxy", version, region_name)
+    cni_new: str = get_default_version("vpc-cni", version, region_name)
+    autoscaler_new: str = add_on_dict[version]["cluster-autoscaler"]
 
     try:
         for pod in rep.items:
             images: List[str] = [c.image for c in pod.spec.containers]
             image = "".join(images)
-            coredns_new = add_on_dict[version].get("coredns")
-            kubeproxy_new = add_on_dict[version].get("kube-proxy")
-            autoscaler_new = add_on_dict[version].get("cluster-autoscaler")
-            cni_new = add_on_dict[version].get("vpc-cni")
             _current_image = image.rsplit(":", maxsplit=1)[-1]
             _cluster_ver = int("".join(_current_image.replace("v", "").replace("-", ".").split(".")[:3]))
-            new_version_int = int(version.replace(".", ""))
-            image_base_uri: str = image.split(":")[0]
-            coredns_new_version: str = f"v{coredns_new}-eksbuild.1"
+            _image_base_uri: str = image.split(":", maxsplit=1)[0]
 
-            if "coredns" in pod.metadata.name and _current_image != coredns_new_version:
+            if "coredns" in pod.metadata.name and _current_image != coredns_new:
                 logger.info(
-                    "%s Current Version = %s Updating to = v%s-eksbuild.1",
+                    "%s Current Version = %s Updating to = %s",
                     pod.metadata.name,
                     _current_image,
                     coredns_new,
                 )
-                body = {
-                    "spec": {
-                        "template": {
-                            "spec": {
-                                "containers": [
-                                    {
-                                        "name": "coredns",
-                                        "image": f"{image_base_uri}:{coredns_new_version}",
-                                    }
-                                ]
-                            }
-                        }
-                    }
-                }
+                coredns_deployment_body = _container_spec("coredns", _image_base_uri, coredns_new)
                 if flag_core:
                     apps_v1_api.patch_namespaced_deployment(
-                        name="coredns", namespace="kube-system", body=body, pretty=True
+                        name="coredns", namespace="kube-system", body=coredns_deployment_body, pretty=True
                     )
+                    update_eks_addon(cluster_name, "coredns", region_name, coredns_new)
+
+                    # If the cluster is LTE 1.7, patch the CoreDNS ConfigMap.
                     if _cluster_ver <= 170:
                         with open("eksupgrade/src/S3Files/core-dns.yaml", "r", encoding="utf-8") as coredns_yaml:
-                            body = yaml.safe_load(coredns_yaml)
-                        core_v1_api.patch_namespaced_config_map(name="coredns", namespace="kube-system", body=body)
+                            _coredns_configmap_body = yaml.safe_load(coredns_yaml)
+                        core_v1_api.patch_namespaced_config_map(
+                            name="coredns", namespace="kube-system", body=_coredns_configmap_body
+                        )
                     flag_core = False
                 time.sleep(20)
 
@@ -370,54 +443,36 @@ def update_addons(cluster_name: str, version: str, vpc_pass: bool, region_name: 
                     cluster_name=cluster_name,
                     region=region_name,
                     original_name=pod.metadata.name,
-                    old_pods_name=old_pods_name,
+                    old_pods_names=old_pods_names,
                     pod_name="kube-dns",
                     namespace="kube-system",
                 )
                 logger.info("Old CoreDNS Pod: %s - New CoreDNS Pod: %s", pod.metadata.name, new_pod_name)
                 queue.put([cluster_name, "kube-system", new_pod_name, "coredns", region_name])
             elif "kube-proxy" in pod.metadata.name:
-                if new_version_int <= 118:
-                    final_ender = "eksbuild.1"
-                else:
-                    final_ender = "eksbuild.2"
-
-                # TODO: Handle versions better and rework this logic so we don't have to do this.
-                kubeproxy_new = re.sub(r"-eksbuild.*", "", kubeproxy_new)
-                _new_kubeproxy_version: str = f"v{kubeproxy_new}-{final_ender}"
-
-                if _current_image != _new_kubeproxy_version:
+                if _current_image != kubeproxy_new:
                     logger.info(
                         "%s Current version: %s Updating to: %s",
                         pod.metadata.name,
                         _current_image,
-                        _new_kubeproxy_version,
+                        kubeproxy_new,
                     )
-                    body = {
-                        "spec": {
-                            "template": {
-                                "spec": {
-                                    "containers": [
-                                        {
-                                            "name": "kube-proxy",
-                                            "image": image_base_uri + _new_kubeproxy_version,
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    }
+                    body = _container_spec("kube-proxy", _image_base_uri, kubeproxy_new)
                     if flag_proxy:
                         apps_v1_api.patch_namespaced_daemon_set(
                             name="kube-proxy", namespace="kube-system", body=body, pretty=True
                         )
+                        _update_response_proxy = update_eks_addon(
+                            cluster_name, "kube-proxy", region_name, kubeproxy_new
+                        )
+                        logger.info("Update kube-proxy Call: %s", _update_response_proxy)
                         flag_proxy = False
                     time.sleep(20)
                     new_pod_name = sort_pods(
                         cluster_name=cluster_name,
                         region=region_name,
                         original_name=pod.metadata.name,
-                        old_pods_name=old_pods_name,
+                        old_pods_names=old_pods_names,
                         pod_name="kube-proxy",
                         namespace="kube-system",
                     )
@@ -428,17 +483,7 @@ def update_addons(cluster_name: str, version: str, vpc_pass: bool, region_name: 
                 logger.info(
                     "%s Current Version = %s Updating To = v%s", pod.metadata.name, _current_image, autoscaler_new
                 )
-                body = {
-                    "spec": {
-                        "template": {
-                            "spec": {
-                                "containers": [
-                                    {"name": "cluster-autoscaler", "image": f"{image_base_uri}:v{autoscaler_new}"}
-                                ]
-                            }
-                        }
-                    }
-                }
+                body = _container_spec("cluster-autoscaler", _image_base_uri, f"v{autoscaler_new}")
                 if flag_scaler:
                     apps_v1_api.patch_namespaced_deployment(
                         name="cluster-autoscaler", namespace="kube-system", body=body, pretty=True
@@ -449,50 +494,56 @@ def update_addons(cluster_name: str, version: str, vpc_pass: bool, region_name: 
                     cluster_name=cluster_name,
                     region=region_name,
                     original_name=pod.metadata.name,
-                    old_pods_name=old_pods_name,
+                    old_pods_names=old_pods_names,
                     pod_name="cluster-autoscaler",
                     namespace="kube-system",
                 )
                 logger.info("old Cluster AutoScaler Pod %s - new AutoScaler pod %s", pod.metadata.name, new_pod_name)
                 queue.put([cluster_name, "kube-system", new_pod_name, "cluster-autoscaler", region_name])
-            elif "aws-node" in pod.metadata.name and _current_image != f"v{cni_new}" and not vpc_pass:
-                logger.info("%s Current Version = %s Updating To = v%s", pod.metadata.name, _current_image, cni_new)
+            elif "aws-node" in pod.metadata.name and _current_image != cni_new and not vpc_pass:
+                logger.info("%s Current Version = %s Updating To = %s", pod.metadata.name, _current_image, cni_new)
                 if flag_vpc:
                     with open("eksupgrade/src/S3Files/vpc-cni.yaml", "r", encoding="utf-8") as vpc_cni_yaml:
                         body = yaml.safe_load(vpc_cni_yaml)
 
-                    body["spec"]["template"]["spec"]["containers"][0]["image"] = f"{image_base_uri}:v{cni_new}"
+                    body["spec"]["template"]["spec"]["containers"][0]["image"] = f"{_image_base_uri}:{cni_new}"
                     old = body["spec"]["template"]["spec"]["initContainers"][0]["image"]
-                    body["spec"]["template"]["spec"]["initContainers"][0]["image"] = f"{old.split(':')[0]}:v{cni_new}"
+                    body["spec"]["template"]["spec"]["initContainers"][0]["image"] = f"{old.split(':')[0]}:{cni_new}"
                     apps_v1_api.patch_namespaced_daemon_set(
                         namespace="kube-system", name="aws-node", body=body, pretty=True
                     )
+                    _update_response_cni = update_eks_addon(cluster_name, "vpc-cni", region_name, cni_new)
+                    logger.info("Update CNI Call: %s", _update_response_cni)
                     flag_vpc = False
                 time.sleep(20)
                 new_pod_name = sort_pods(
                     cluster_name=cluster_name,
                     region=region_name,
                     original_name=pod.metadata.name,
-                    old_pods_name=old_pods_name,
+                    old_pods_names=old_pods_names,
                     pod_name="aws-node",
                     namespace="kube-system",
                 )
                 logger.info("Old VPC CNI pod: %s - New VPC CNI pod: %s", pod.metadata.name, new_pod_name)
                 queue.put([cluster_name, "kube-system", new_pod_name, "aws-node", region_name])
         queue.join()
-    except Exception as e:
-        logger.error("Exception encountered while attempting to update the addons - Error: %s", e)
-        raise e
+    except Exception as error:
+        logger.error("Exception encountered while attempting to update the addons - Error: %s", error)
+        raise error
 
 
-def delete_pd_policy(pd_name: str) -> None:
+def delete_pd_policy(pd_name: str, namespace: str = "default") -> None:
     """Attempt to delete a Pod Disruption policy."""
-    api_cli = client.PolicyV1beta1Api()
     try:
-        api_response = api_cli.delete_namespaced_pod_disruption_budget(name=pd_name, namespace="default")
+        api_cli = client.PolicyV1beta1Api()
+    except AttributeError:
+        api_cli = client.PolicyV1Api()
+
+    try:
+        api_response = api_cli.delete_namespaced_pod_disruption_budget(name=pd_name, namespace=namespace)
         logger.debug(api_response)
-    except ApiException as e:
-        logger.error("Exception when calling PolicyV1beta1Api->delete_namespaced_pod_disruption_budget: %s", e)
+    except ApiException as error:
+        logger.error("Exception when calling PolicyV1beta1Api->delete_namespaced_pod_disruption_budget: %s", error)
 
 
 def is_cluster_auto_scaler_present(cluster_name: str, region: str) -> List[Union[int, str]]:

--- a/eksupgrade/src/k8s_client.py
+++ b/eksupgrade/src/k8s_client.py
@@ -339,7 +339,7 @@ def update_eks_addon(cluster_name: str, addon: str, region: str, version: str) -
 
 @cache
 def get_addon_versions(version: str, region: str) -> List[Dict[str, Any]]:
-    """Get target addon versions."""
+    """Get addon versions for the associated Kubernetes `version`."""
     eks_client = boto3.client("eks", region_name=region)
     addon_versions: List[Dict[str, Any]] = eks_client.describe_addon_versions(kubernetesVersion=version).get(
         "addons", []

--- a/eksupgrade/starter.py
+++ b/eksupgrade/starter.py
@@ -246,7 +246,7 @@ def main(args) -> None:
 
         # checking auto scaler present and the value associated from it
 
-        is_present, replicas_value = is_cluster_auto_scaler_present(ClusterName=cluster_name, regionName=region)
+        is_present, replicas_value = is_cluster_auto_scaler_present(cluster_name=cluster_name, region=region)
 
         if is_present:
             cluster_auto_enable_disable(


### PR DESCRIPTION
## Summary

### Changes

The goal of this PR is to update the standard workflow to:

- pull default version for a target upgrade from the EKS Add-on API and use that versus hardcoded version in version_dict.json` for everything except `cluster-autoscaler`.
- update `cluster-autoscaler` hardcoded version tags where relevant (and add missing entries for target versions).
- add method call to the update addon EKS API endpoint following manual pod recreation with new target version tags.
- Fix the workflow so it works for the enduser

### User experience

The user now always pulls the default version from the EKS API for official add-ons.  This is then used to subsequently perform an HTTP request to initiate a formal EKS addon upgrade.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
