### PR TITLE
fix: Remove unused args,  formatted eksctl commands

### DIFF
--- a/eksupgrade/src/boto_aws.py
+++ b/eksupgrade/src/boto_aws.py
@@ -70,9 +70,9 @@ def get_latest_instance(asg_name: str, add_time: datetime.datetime, region: str)
         raise e
 
 
-def wait_for_ready(instanceid: str, regionName: str) -> bool:
+def wait_for_ready(instanceid: str, region: str) -> bool:
     """Wait for the cluster to pass the status checks."""
-    ec2_client = boto3.client("ec2", region_name=regionName)
+    ec2_client = boto3.client("ec2", region_name=region)
     logger.info("Instance %s waiting for the instance to pass the Health Checks", instanceid)
     try:
         while (
@@ -89,9 +89,9 @@ def wait_for_ready(instanceid: str, regionName: str) -> bool:
     return True
 
 
-def check_asg_autoscaler(asg_name: str, regionName: str) -> bool:
+def check_asg_autoscaler(asg_name: str, region: str) -> bool:
     """Check whether the autoscaling is present or not."""
-    asg_client = boto3.client("autoscaling", region_name=regionName)
+    asg_client = boto3.client("autoscaling", region_name=region)
     response = asg_client.describe_auto_scaling_groups(AutoScalingGroupNames=[asg_name])
     pat = "k8s.io/cluster-autoscaler/enabled"
     asg_list = []
@@ -101,9 +101,9 @@ def check_asg_autoscaler(asg_name: str, regionName: str) -> bool:
     return bool(asg_list)
 
 
-def enable_disable_autoscaler(asg_name: str, action: str, regionName: str) -> str:
+def enable_disable_autoscaler(asg_name: str, action: str, region: str) -> str:
     """Enable or disable the autoscaler depending on the provided action."""
-    asg_client = boto3.client("autoscaling", region_name=regionName)
+    asg_client = boto3.client("autoscaling", region_name=region)
     try:
         if action == "pause":
             asg_client.delete_tags(

--- a/eksupgrade/src/eksctlfinal.py
+++ b/eksupgrade/src/eksctlfinal.py
@@ -35,7 +35,7 @@ def get_bearer_token(cluster_id: str, region: str) -> str:
 
     params = {
         "method": "GET",
-        "url": "https://sts.{}.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15".format(region),
+        "url": f"https://sts.{region}.amazonaws.com/?Action=GetCallerIdentity&Version=2011-06-15",
         "body": {},
         "headers": {"x-k8s-aws-id": cluster_id},
         "context": {},
@@ -52,22 +52,21 @@ def get_bearer_token(cluster_id: str, region: str) -> str:
     return "k8s-aws-v1." + re.sub(r"=*", "", base64_url)
 
 
-def loading_config(cluster_name: str, regionName: str) -> str:
+def loading_config(cluster_name: str, region: str) -> str:
     """Load the kubeconfig with STS."""
-    eks = boto3.client("eks", region_name=regionName)
+    eks = boto3.client("eks", region_name=region)
     resp = eks.describe_cluster(name=cluster_name)
-    endPoint = resp["cluster"]["endpoint"]
     configs = client.Configuration()
-    configs.host = endPoint
+    configs.host = resp["cluster"]["endpoint"]
     configs.verify_ssl = False
     configs.debug = False
-    configs.api_key = {"authorization": "Bearer " + get_bearer_token(cluster_name, regionName)}
+    configs.api_key = {"authorization": "Bearer " + get_bearer_token(cluster_name, region)}
     client.Configuration.set_default(configs)
-    return "Initialiazed"
+    return "Initialized"
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-def upgrade_cluster(region, clust_name, d, bclient, version):
+def upgrade_cluster(clust_name, d, bclient, version):
     start_time = time.ctime()
     start = time.time()
     logger.info("The cluster Upgrade Started At %s", str(start_time))
@@ -76,9 +75,9 @@ def upgrade_cluster(region, clust_name, d, bclient, version):
     logger.info("cluster version before upgrade %s", response["cluster"]["version"])  # to log present version
     d["cluster_prev_version"] = response["cluster"]["version"]
     args = (
-        "~/eksctl upgrade cluster --name=" + clust_name + " --version " + version + " --approve"
+        f"~/eksctl upgrade cluster --name={clust_name} --version {version} --approve"
     )  # upgrades cluster to one version above
-    output = subprocess.call(args, shell=True)
+    subprocess.call(args, shell=True)
     response = bclient.describe_cluster(name=clust_name)
     logger.info("cluster version after upgrade %s", response["cluster"]["version"])  # to log updated/new version
     d["cluster_updated_version:"] = response["cluster"]["version"]
@@ -92,7 +91,7 @@ def upgrade_cluster(region, clust_name, d, bclient, version):
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # upgrades addon available in given cluster
-def add_on_upgrade(region, clust_name, d, v1):
+def add_on_upgrade(region, clust_name, d):
     logger.info("addon upgrade started")
     start_time = time.ctime()
     start = time.time()
@@ -107,10 +106,10 @@ def add_on_upgrade(region, clust_name, d, v1):
         logger.info("%s Current Version = %s", pod.metadata.name, pod.spec.containers[0].image.split(":")[-1])
         d["addonsbeforeupdate"][pod.metadata.name] = pod.spec.containers[0].image.split(":")[-1]
 
-    args = "~/eksctl utils update-kube-proxy --cluster=" + clust_name + " --approve"  # to update kube-proxy
-    output = subprocess.call(args, shell=True)
-    args = "~/eksctl utils update-coredns --cluster=" + clust_name + " --approve"  # to update coredns
-    output = subprocess.call(args, shell=True)
+    args = f"~/eksctl utils update-kube-proxy --cluster={clust_name} --approve"  # to update kube-proxy
+    subprocess.call(args, shell=True)
+    args = f"~/eksctl utils update-coredns --cluster={clust_name} --approve"  # to update coredns
+    subprocess.call(args, shell=True)
 
     output = botoclient("us-west-2").list_addons(clusterName=clust_name)
 
@@ -125,14 +124,14 @@ def add_on_upgrade(region, clust_name, d, v1):
 
                 if response["addon"]["addonVersion"] != vpc_version:
                     args = (
-                        "~/eksctl update addon --name vpc-cni  --version " + vpc_version + " --cluster " + clust_name
+                        f"~/eksctl update addon --name vpc-cni  --version {vpc_version} --cluster {clust_name}"
                     )  # to update aws-node
-                    output = subprocess.call(args, shell=True)
+                    subprocess.call(args, shell=True)
         except Exception as e:
             logger.error("Failed to fetch Cluster OIDC value for cluster name: %s - Error: %s", clust_name, e)
     else:
-        args = "~/eksctl utils update-aws-node --cluster=" + clust_name + " --approve"
-        output = subprocess.call(args, shell=True)
+        args = f"~/eksctl utils update-aws-node --cluster={clust_name} --approve"
+        subprocess.call(args, shell=True)
 
     logger.info("addons update completed")
     end = time.time()
@@ -144,8 +143,8 @@ def add_on_upgrade(region, clust_name, d, v1):
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # retrieves the self managed nodegroup name
-def get_old_smg_node_groups(region, clust_name, bclient):
-    args = "~/eksctl get nodegroup --cluster=" + clust_name + " -o json"
+def get_old_smg_node_groups(clust_name, bclient):
+    args = f"~/eksctl get nodegroup --cluster={clust_name} -o json"
     output = subprocess.check_output(args, shell=True)
     output = json.loads(output)  # to extract all nodegroups present in the cluster
     old_smg = []
@@ -161,13 +160,13 @@ def get_old_smg_node_groups(region, clust_name, bclient):
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # updates the unmanaged nodegroup  by migrating to new nodegroup
-def update_unmanaged_nodegroup(region, clust_name, d, bclient):
+def update_unmanaged_nodegroup(clust_name, d, bclient):
     start_time = time.ctime()
     start = time.time()
     logger.info("update managed nodegroups Started At %s", start_time)
 
-    old_smg = get_old_smg_node_groups(region, clust_name, bclient)  # extract SELF MANAGED NODEGROUPS
-    args = "~/eksctl get nodegroup --cluster=" + clust_name + " -o json"
+    old_smg = get_old_smg_node_groups(clust_name, bclient)  # extract SELF MANAGED NODEGROUPS
+    args = f"~/eksctl get nodegroup --cluster={clust_name} -o json"
     output = subprocess.check_output(args, shell=True)
     output = json.loads(output)
     response = bclient.list_nodegroups(
@@ -186,16 +185,16 @@ def update_unmanaged_nodegroup(region, clust_name, d, bclient):
             for i in old_smg:
                 # creates a node group with CONTROL PLANE version
                 args = f"~/eksctl create nodegroup --cluster={clust_name}"
-                output = subprocess.call(args, shell=True)
-                ls = get_old_smg_node_groups(region, clust_name, bclient)
+                subprocess.call(args, shell=True)
+                ls = get_old_smg_node_groups(clust_name, bclient)
                 time.sleep(60)
                 # DRAINS the old node groups
                 args = f"~/eksctl drain nodegroup --cluster={clust_name} --name={i}"
-                output = subprocess.call(args, shell=True)
+                subprocess.call(args, shell=True)
                 time.sleep(60)
                 # DELETES the old node groups
                 args = f"~/eksctl delete nodegroup --cluster={clust_name} --name={i}"
-                output = subprocess.call(args, shell=True)
+                subprocess.call(args, shell=True)
         except Exception as e:
             logger.error("pdb set cant delete pods - Error: %s", e)
     else:
@@ -204,7 +203,7 @@ def update_unmanaged_nodegroup(region, clust_name, d, bclient):
 
     logger.info("**Logging unmanaged nodegroups....waiting for nodegroup to be active")
     time.sleep(240)
-    args = "~/eksctl get nodegroup --cluster=" + clust_name + " -o json"
+    args = f"~/eksctl get nodegroup --cluster={clust_name} -o json"
     output = subprocess.check_output(args, shell=True)
     output = json.loads(output)
     response = bclient.list_nodegroups(
@@ -230,16 +229,15 @@ def update_unmanaged_nodegroup(region, clust_name, d, bclient):
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # creates a managed nodegroup
-def create_managed_nodegroup(region, clust_name, client):
+def create_managed_nodegroup(clust_name, client):
     start_time = time.ctime()
-    start = time.time()
     logger.info("creation of managed nodegroups Started At %s", str(start_time))
 
     start_time = time.ctime()
     start = time.time()
     logger.info("The Addons Upgrade Started At %s", str(start_time))
 
-    args = "~/eksctl create nodegroup --managed --cluster=" + clust_name
+    args = f"~/eksctl create nodegroup --managed --cluster={clust_name}"
     output = subprocess.call(args, shell=True)
 
     end = time.time()
@@ -251,12 +249,12 @@ def create_managed_nodegroup(region, clust_name, client):
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # creates unmanaged nodegroup
-def create_unmanaged_nodegroup(region, clust_name, client):
+def create_unmanaged_nodegroup(clust_name, client):
     start_time = time.ctime()
     start = time.time()
     logger.info("creation of Unmanaged nodegroups Started At %s in cluster: %s", str(start_time), clust_name)
 
-    args = "~/eksctl create nodegroup --cluster=" + clust_name
+    args = f"~/eksctl create nodegroup --cluster={clust_name}"
     output = subprocess.call(args, shell=True)
 
     end = time.time()
@@ -289,7 +287,7 @@ def update_managed_nodegroup(region, clust_name, version, d, bclient):
             logger.info("nodegroup %s version before upgrade is %s", i, response["nodegroup"]["version"])
             # UPDATES MANAGED NODEGROUP
             args = f"~/eksctl upgrade nodegroup --name={i} --cluster={clust_name} --kubernetes-version={version}"
-            output = subprocess.call(args, shell=True)
+            subprocess.call(args, shell=True)
             response = bclient.describe_nodegroup(clusterName=clust_name, nodegroupName=i)
             logger.info("nodegroup %s version after upgrade is %s", i, response["nodegroup"]["version"])
             d["managed_nodegroup_after_update"][i] = response["nodegroup"]["version"]
@@ -315,19 +313,16 @@ def eksctl_execute(args):
     bclient = botoclient(region)
     loading_config(clust_name, region)
 
-    v1 = client.CoreV1Api()
-
-    rep = v1.list_namespaced_pod("kube-system")
     d = {}
     # ~~~~~~~~~~~~~~~~~~~~~~~~~UPGRADE
     # call to upgrade cluster to latest version
-    d = upgrade_cluster(region, clust_name, d, bclient, version)
+    d = upgrade_cluster(clust_name, d, bclient, version)
     # #call to upgrade addons to latest version
-    d = add_on_upgrade(region, clust_name, d, v1)
+    d = add_on_upgrade(region, clust_name, d)
     # call to update managed nodegroup
     d = update_managed_nodegroup(region, clust_name, str(version), d, bclient)
     # call to update unmanaged nodegroup b
-    d = update_unmanaged_nodegroup(region, clust_name, d, bclient)
+    d = update_unmanaged_nodegroup(clust_name, d, bclient)
     loading_config(clust_name, region)
 
     v1 = client.CoreV1Api()

--- a/eksupgrade/src/eksctlfinal.py
+++ b/eksupgrade/src/eksctlfinal.py
@@ -74,9 +74,7 @@ def upgrade_cluster(clust_name, d, bclient, version):
     response = bclient.describe_cluster(name=clust_name)  # to describe the cluster using boto3
     logger.info("cluster version before upgrade %s", response["cluster"]["version"])  # to log present version
     d["cluster_prev_version"] = response["cluster"]["version"]
-    args = (
-        f"~/eksctl upgrade cluster --name={clust_name} --version {version} --approve"
-    )  # upgrades cluster to one version above
+    args = f"~/eksctl upgrade cluster --name={clust_name} --version {version} --approve"  # upgrades cluster to one version above
     subprocess.call(args, shell=True)
     response = bclient.describe_cluster(name=clust_name)
     logger.info("cluster version after upgrade %s", response["cluster"]["version"])  # to log updated/new version
@@ -123,9 +121,7 @@ def add_on_upgrade(region, clust_name, d):
                 response = botoclient("us-west-2").describe_addon(clusterName=clust_name, addonName="vpc-cni")
 
                 if response["addon"]["addonVersion"] != vpc_version:
-                    args = (
-                        f"~/eksctl update addon --name vpc-cni  --version {vpc_version} --cluster {clust_name}"
-                    )  # to update aws-node
+                    args = f"~/eksctl update addon --name vpc-cni  --version {vpc_version} --cluster {clust_name}"  # to update aws-node
                     subprocess.call(args, shell=True)
         except Exception as e:
             logger.error("Failed to fetch Cluster OIDC value for cluster name: %s - Error: %s", clust_name, e)

--- a/eksupgrade/src/k8s_client.py
+++ b/eksupgrade/src/k8s_client.py
@@ -249,13 +249,13 @@ def addon_status(cluster_name: str, new_pod_name: str, region: str, namespace: s
 
 
 def sort_pods(
-        cluster_name: str,
-        region: str,
-        original_name: str,
-        pod_name: str,
-        old_pods_names: List[str],
-        namespace: str,
-        count: int = 90,
+    cluster_name: str,
+    region: str,
+    original_name: str,
+    pod_name: str,
+    old_pods_names: List[str],
+    namespace: str,
+    count: int = 90,
 ) -> str:
     """Sort the pod results."""
     if not count:

--- a/eksupgrade/src/k8s_client.py
+++ b/eksupgrade/src/k8s_client.py
@@ -83,15 +83,15 @@ def get_bearer_token(cluster_id: str, region: str) -> str:
     return "k8s-aws-v1." + re.sub(r"=*", "", base64_url)
 
 
-def loading_config(cluster_name, regionName) -> str:
+def loading_config(cluster_name: str, region: str) -> str:
     """loading kubeconfig with sts"""
-    eks = boto3.client("eks", region_name=regionName)
+    eks = boto3.client("eks", region_name=region)
     resp = eks.describe_cluster(name=cluster_name)
     configs = client.Configuration()
     configs.host = resp["cluster"]["endpoint"]
     configs.verify_ssl = False
     configs.debug = False
-    configs.api_key = {"authorization": "Bearer " + get_bearer_token(cluster_name, regionName)}
+    configs.api_key = {"authorization": "Bearer " + get_bearer_token(cluster_name, region)}
     client.Configuration.set_default(configs)
     return "Initialized"
 
@@ -249,13 +249,13 @@ def addon_status(cluster_name: str, new_pod_name: str, region: str, namespace: s
 
 
 def sort_pods(
-    cluster_name: str,
-    region: str,
-    original_name: str,
-    pod_name: str,
-    old_pods_names: List[str],
-    namespace: str,
-    count: int = 90,
+        cluster_name: str,
+        region: str,
+        original_name: str,
+        pod_name: str,
+        old_pods_names: List[str],
+        namespace: str,
+        count: int = 90,
 ) -> str:
     """Sort the pod results."""
     if not count:

--- a/eksupgrade/src/preflight_module.py
+++ b/eksupgrade/src/preflight_module.py
@@ -1016,7 +1016,7 @@ def nodegroup_customami(errors, cluster_name, region, report, customer_report, u
             else:
                 instance_id = i.spec.provider_id.split("/")[-1]
                 node_type = i.status.node_info.os_image
-                if "windows" in (node_type).lower():
+                if "windows" in node_type.lower():
                     node_type = "windows"
                 ec2Client = boto3.client("ec2", region_name=region)
                 res = ec2Client.describe_instances(InstanceIds=[instance_id])

--- a/tests/test_k8s_client.py
+++ b/tests/test_k8s_client.py
@@ -30,5 +30,5 @@ def test_get_bearer_token(sts_client, eks_cluster, cluster_name, region) -> None
 
 def test_loading_config(eks_client, eks_cluster, cluster_name, region) -> None:
     """Test the loading_config method."""
-    result = loading_config(cluster_name, regionName=region)
+    result = loading_config(cluster_name, region=region)
     assert result == "Initialized"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 MD043 -->

Resolves https://github.com/aws-samples/amazon-eks-one-click-cluster-upgrade/issues/24

## Summary

### Changes

- Removed `region` argument from methods referenced in Issue #24.
- Updated arg name from `regionName` to `region` in eksctlfinal and k8s_client.
- Formatted eksctl commands to use fstrings consistently.
- Removed `v1` from `add_on_upgrade` since it is set inside the method.
- Removed taget assignment for the subprocess calls which used to be logged in a previous version.


**Note** : `loading_config` & `get_bearer_token` are redundant methods, but didn't change them in this PR to reduce the radius. 


### User experience

No Changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [X] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
